### PR TITLE
travis: Drop Node.js 0.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: node_js
 node_js:
-  - "0.8"
   - "0.10"
 before_script:
   - npm install -g grunt-cli


### PR DESCRIPTION
There are upstream dependencies which use caret version numbers (e.g. `minimatch@^0.3.0`) which isn't supported by the older npm version that came with with Node.js 0.8.

The Travis build has been failing since last month (which is when those other projects changed their dependencies), but should be passing again after this.
